### PR TITLE
Add toast notifications and error handling to GUI tools toggle

### DIFF
--- a/src/components/MCPServerManager.tsx
+++ b/src/components/MCPServerManager.tsx
@@ -5,6 +5,7 @@ import { Badge } from './ui/badge';
 import { Switch } from './ui/switch';
 import { MCPServerStatus } from '../types/docker';
 import { Wrench, Clock, BarChart3, Link, RefreshCw, Radio } from 'lucide-react';
+import { toast } from 'sonner';
 
 interface LocalMCPServerStatus extends MCPServerStatus {
   totalRequests: number;
@@ -236,23 +237,50 @@ export const MCPServerConfigCard: React.FC = () => {
   };
 
   const handleToggleGUITools = async (enabled: boolean) => {
-    try {
-      const result = await window.settingsAPI.updateSettings({ enableGUITools: enabled });
-      if (result.success) {
-        setEnableGUITools(enabled);
+    const previousState = enableGUITools;
+    const loadingToastId = toast.loading(`${enabled ? 'Enabling' : 'Disabling'} GUI tools...`);
 
-        // Restart MCP server after GUI tools setting change
-        try {
-          const restartResult = await window.mcpAPI.restartServer();
-          if (restartResult.success && restartResult.status) {
-            console.log('MCP server restarted successfully after GUI tools change');
-          }
-        } catch (restartError) {
-          console.error('Failed to restart MCP server after GUI tools change:', restartError);
+    try {
+      // Update settings first
+      const result = await window.settingsAPI.updateSettings({ enableGUITools: enabled });
+      if (!result.success) {
+        throw new Error('Failed to update settings');
+      }
+
+      // Restart MCP server to apply the change
+      try {
+        const restartResult = await window.mcpAPI.restartServer();
+        if (restartResult.success && restartResult.status) {
+          // Only update UI state after successful restart
+          setEnableGUITools(enabled);
+          toast.dismiss(loadingToastId);
+          toast.success(`GUI tools ${enabled ? 'enabled' : 'disabled'} successfully`);
+          console.log('MCP server restarted successfully after GUI tools change');
+        } else {
+          throw new Error('Server restart failed');
         }
+      } catch (restartError) {
+        console.error('Failed to restart MCP server after GUI tools change:', restartError);
+
+        // Rollback settings to previous state
+        await window.settingsAPI.updateSettings({ enableGUITools: previousState });
+
+        toast.dismiss(loadingToastId);
+        toast.error(
+          `Failed to ${enabled ? 'enable' : 'disable'} GUI tools. Server restart failed. Settings reverted.`,
+          { duration: 5000 }
+        );
+
+        // Keep UI state unchanged since we rolled back the settings
+        throw restartError;
       }
     } catch (error) {
       console.error('Failed to update GUI tools setting:', error);
+      toast.dismiss(loadingToastId);
+      toast.error(
+        `Failed to ${enabled ? 'enable' : 'disable'} GUI tools: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        { duration: 5000 }
+      );
     }
   };
 

--- a/src/components/MCPServerManager.tsx
+++ b/src/components/MCPServerManager.tsx
@@ -285,8 +285,8 @@ export const MCPServerConfigCard: React.FC = () => {
           console.error('Critical: Failed to rollback settings after server restart failure');
         }
 
-        // Keep UI state unchanged if rollback succeeded, or update it if rollback failed
-        throw restartError;
+        // Error already handled with appropriate toast notification - don't propagate to outer catch
+        return;
       }
     } catch (error) {
       console.error('Failed to update GUI tools setting:', error);

--- a/src/components/MCPServerManager.tsx
+++ b/src/components/MCPServerManager.tsx
@@ -262,16 +262,30 @@ export const MCPServerConfigCard: React.FC = () => {
       } catch (restartError) {
         console.error('Failed to restart MCP server after GUI tools change:', restartError);
 
-        // Rollback settings to previous state
-        await window.settingsAPI.updateSettings({ enableGUITools: previousState });
+        // Attempt to rollback settings to previous state
+        const rollbackResult = await window.settingsAPI.updateSettings({ enableGUITools: previousState });
 
         toast.dismiss(loadingToastId);
-        toast.error(
-          `Failed to ${enabled ? 'enable' : 'disable'} GUI tools. Server restart failed. Settings reverted.`,
-          { duration: 5000 }
-        );
 
-        // Keep UI state unchanged since we rolled back the settings
+        if (rollbackResult.success) {
+          // Rollback successful - UI stays at previous state, settings reverted
+          toast.error(
+            `Failed to ${enabled ? 'enable' : 'disable'} GUI tools. Server restart failed. Settings reverted.`,
+            { duration: 5000 }
+          );
+        } else {
+          // Rollback failed - critical state inconsistency!
+          // Backend settings are in the new state, but server didn't restart
+          // Update UI to match backend settings and warn user
+          setEnableGUITools(enabled);
+          toast.error(
+            `Critical: Server restart failed AND settings rollback failed. Settings are ${enabled ? 'enabled' : 'disabled'} but not applied. Please restart the app.`,
+            { duration: 10000 }
+          );
+          console.error('Critical: Failed to rollback settings after server restart failure');
+        }
+
+        // Keep UI state unchanged if rollback succeeded, or update it if rollback failed
         throw restartError;
       }
     } catch (error) {


### PR DESCRIPTION
## Summary
Enhanced the GUI tools toggle functionality in MCPServerManager with user-facing toast notifications and improved error handling with automatic settings rollback on failure.

## Key Changes
- **Toast Notifications**: Added loading, success, and error toast messages to provide real-time feedback to users during the GUI tools toggle operation
- **Improved Error Handling**: Restructured the try-catch logic to properly handle failures at each step (settings update and server restart)
- **Automatic Rollback**: Implemented automatic rollback of settings to the previous state if the server restart fails, ensuring consistency between UI state and backend settings
- **Better State Management**: UI state (`setEnableGUITools`) is now only updated after successful server restart, preventing UI-state mismatch with actual settings
- **Enhanced User Feedback**: Error messages now include specific details about what failed and that settings were reverted if applicable

## Implementation Details
- Loading toast is dismissed and replaced with success/error toast based on operation outcome
- Settings update is performed first, followed by server restart
- If restart fails, settings are automatically reverted to the previous state before showing error toast
- Error messages include duration specification (5 seconds) for better visibility
- Console logging is preserved for debugging purposes

https://claude.ai/code/session_01VCxiRng8bcMNdhiPUEbnyC